### PR TITLE
move event creation to server

### DIFF
--- a/client/views/events/event_new.coffee
+++ b/client/views/events/event_new.coffee
@@ -7,11 +7,6 @@ Template.new_event.events
   'submit .create-event': (e) ->
     e.preventDefault()
     event = window.events_at_penn.parse_event_from_form $('.create-event')
-
-    user = Meteor.user()
-    event.creator = user._id
-    event.creator_name = user.profile.name
-
-    event_id = Events.insert(event)
-    Meteor.call('create_event', event_id)
-    Meteor.Router.to "/event/#{event_id}"
+    Meteor.call('create_event', event, (error, id) ->
+      Meteor.Router.to "/event/#{id}"
+    )

--- a/collections/events.coffee
+++ b/collections/events.coffee
@@ -1,11 +1,20 @@
 this.Events = new Meteor.Collection("events")
 
 Meteor.methods
-  create_event: (event_id) ->
+  create_event: (event) ->
+    user = Meteor.user()
+
+    event.creator = user._id
+    event.creator_name = user.profile.name
+
+    event_id = Events.insert(event)
+
     Meteor.users.update(Meteor.userId(), {$push: {"profile.events": event_id}})
     followers = Meteor.user().profile.followers or []
     if followers.length
       Meteor.users.update(_id: {$in: followers}, {$push: {"profile.event_queue": event_id}})
+
+    return event_id
 
   # pulling events, pulls all occurences of that event out,
   # so if the user created the event or follows someone who created it,


### PR DESCRIPTION
This prepares us to remove the ability for users to create bad events.
It also closely follows the example in `Discover Meteor`.
